### PR TITLE
add stop-backend command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [CLI commands](core/README.md#cli-commands) for more details on the availabl
 ### 3. Install the companion extension:
 
 - Chrome:
-  - ~~From Chrome's webstore~~ (currently in review process)
+  - From [Chrome's webstore](https://chrome.google.com/webstore/detail/network-overrides/kineamfncbnialdjlpmhibfjegiiphkk)
   - Manually:
     1. Download the `network-overrides-<version>.crx` from the [latest release](https://github.com/miguel-silva/network-overrides/releases/latest)
     2. Open `chrome://extensions/`, enable Developer Mode and drag-and-drop the downloaded extension over the extensions page.
@@ -93,7 +93,7 @@ The browser extension is responsible for:
 
 ## Next steps
 
-- [ ] add `network-overrides stop-backend` command
+- [x] add `network-overrides stop-backend` command
 - [ ] automatically stop shared backend when running in a background process and becomes idle
 - [ ] add tests
 - [ ] convert to TypeScript

--- a/core/README.md
+++ b/core/README.md
@@ -16,6 +16,12 @@ Starts the shared overrides backend in port `8117`. In case the port is already 
 
 Running it with the `--background` flag will start it as a background (detached) process instead.
 
+### stop-backend
+
+Format: `network-overrides stop-backend`
+
+Stops the shared overrides backend, making it exit normally.
+
 ### add
 
 Format: `network-overrides add <override-set-id> <overrides>`

--- a/core/backend/backend.js
+++ b/core/backend/backend.js
@@ -23,6 +23,12 @@ app.get('/', { websocket: true }, (connection) => {
   });
 });
 
+app.delete('/', () => {
+  stop();
+
+  return true;
+});
+
 app.get('/overrides', async () => {
   console.log('returning overrides', overridesMap);
 
@@ -68,6 +74,19 @@ function start(port) {
 
       throw error;
     });
+}
+
+function stop() {
+  console.log('stopping server');
+
+  // close websocket connections with completed status code
+  overridesWebsocketConnectionSet.forEach((connection) =>
+    connection.socket.close(1000),
+  );
+
+  overridesWebsocketConnectionSet.clear();
+
+  app.close();
 }
 
 function sendOverridesMapToClients() {

--- a/core/cli.js
+++ b/core/cli.js
@@ -4,6 +4,7 @@ const path = require('path');
 const {
   startBackend,
   spawnBackendProcessInBackground,
+  stopServer,
   addOverrides,
   removeOverrides,
   getOverrides,
@@ -50,6 +51,22 @@ switch (commandName) {
 
         console.error(e);
       }
+    });
+
+    break;
+  }
+
+  case 'stop-backend': {
+    stopServer().catch((e) => {
+      process.exitCode = 1;
+
+      if (e.code === 'ECONNREFUSED') {
+        console.warn('The backend seems to not be running.');
+
+        return;
+      }
+
+      console.error(e);
     });
 
     break;

--- a/core/commands.js
+++ b/core/commands.js
@@ -55,6 +55,12 @@ async function spawnBackendProcessInBackground(options = {}) {
   return serverProcess;
 }
 
+async function stopServer() {
+  await fetch(`${backendUrl}/`, {
+    method: 'DELETE',
+  });
+}
+
 function getOverrides() {
   return fetch(`${backendUrl}/overrides`).then((response) => response.json());
 }
@@ -149,6 +155,7 @@ module.exports = {
   startBackend,
   spawnBackendProcess,
   spawnBackendProcessInBackground,
+  stopServer,
   getOverrides,
   addOverrides,
   removeOverrides,

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-overrides",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "CLI and backend for the Network Overrides browser extension",
   "bin": {
     "network-overrides": "./cli.js"


### PR DESCRIPTION
## Motivation

As of now it is a bit cumbersome to stop the shared backend when it is running in the background. Instead of making the users look for specific process names and network ports, we can make it easier by adding an explicit command.

## Changes

- add `network-overrides stop-backend` command, which communicates to the shared backend process to exit normally.
- add Chrome extension's webstore link.