### PR TITLE
improve spawnBackendProcess

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-overrides",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI and backend for the Network Overrides browser extension",
   "bin": {
     "network-overrides": "./cli.js"


### PR DESCRIPTION
## Changes

- make spawnBackendProcess faster and more reliable by:
  - checking if the backend is already running before starting a useless process
  - after spawning the process, checking multiple times if the backend either started or failed to do so, for a longer period of time
- add some comments