### PR TITLE
Expose SpawnOptions in wrapCommandWithOverrides

### DIFF
--- a/core/commands.js
+++ b/core/commands.js
@@ -114,6 +114,7 @@ async function wrapCommandWithOverrides(
   overrideSetId,
   overrides,
   ensureBackend,
+  commandSpawnOptions,
 ) {
   if (ensureBackend) {
     // start the process in the background, continuing if already running
@@ -146,6 +147,7 @@ async function wrapCommandWithOverrides(
   // start wrapped command
   const subProcess = spawn(subCommandName, subArgs, {
     stdio: 'inherit',
+    ...commandSpawnOptions,
   });
 
   //#region cleanup section

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "network-overrides",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI and backend for the Network Overrides browser extension",
   "bin": {
     "network-overrides": "./cli.js"


### PR DESCRIPTION
## Changes

- add optional `commandSpawnOptions` arg to `wrapCommandWithOverrides` so that the consumer can tweak settings like env vars