### PR TITLE
Migrate extension to Manifest version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 node_modules
 .DS_Store
 
+.vscode/settings.json
+
 network-overrides-*.tgz
+extension.zip

--- a/extension/background/background.html
+++ b/extension/background/background.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head></head>
-  <body>
-    <script src="background.js"></script>
-  </body>
-</html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,14 +1,19 @@
 {
   "name": "Network Overrides",
   "description": "Override network calls. Configurable via network-overrides Node package.",
-  "version": "0.1.0",
-  "manifest_version": 2,
+  "version": "0.2.0",
+  "manifest_version": 3,
   "background": {
-    "page": "background/background.html",
-    "persistent": true
+    "service_worker": "worker/service_worker.js",
+    "type": "module"
   },
-  "permissions": ["webRequest", "webRequestBlocking", "<all_urls>"],
-  "browser_action": {
+  "permissions": [
+    "declarativeNetRequest",
+    "declarativeNetRequestFeedback",
+    "storage"
+  ],
+  "host_permissions": ["*://*/*"],
+  "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {
       "16": "/images/network-overrides-16.png",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Network Overrides",
   "description": "Override network calls. Configurable via network-overrides Node package.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "manifest_version": 3,
   "background": {
     "service_worker": "worker/service_worker.js",

--- a/extension/worker/service_worker.js
+++ b/extension/worker/service_worker.js
@@ -98,7 +98,7 @@ function closeSocket() {
   stopHeartbeat();
 }
 
-chrome.declarativeNetRequest.onRuleMatchedDebug.addListener((info) =>
+chrome.declarativeNetRequest.onRuleMatchedDebug?.addListener((info) =>
   console.log('rule matched', info),
 );
 

--- a/extension/worker/service_worker.js
+++ b/extension/worker/service_worker.js
@@ -137,7 +137,7 @@ async function updateState(newState) {
         overrides.map(({ from, to }) => {
           return {
             from: from,
-            to: to,
+            to: to.replaceAll('$', '\\'),
           };
         }),
       )


### PR DESCRIPTION
Special thanks to @danielkutt for doing most of the work 🥇 

## Motivation

The deprecation of MV2 in Chrome came along with the removal of support for:
- background pages
- the `webRequest` API

## Changes

- migrate from a background page to a service worker
- migrate from `webRequest` to `declarativeNetRequest` API